### PR TITLE
FB embedded page feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,53 @@
     function loadHoverboardApp() {
       requestAnimationFrame(() => {
         const app = document.createElement('hoverboard-app');
+
+        const gdgFeedContainer = document.createElement('div');
+        gdgFeedContainer.setAttribute('slot', 'gdg-cochabamba-feed');
+        gdgFeedContainer.setAttribute('class', 'gdg-feed-container');
+
+        const gdgFeed = document.createElement('div');
+        gdgFeed.setAttribute('id', 'gdgFeed');
+        gdgFeed.setAttribute('class', 'fb-page');
+        gdgFeed.setAttribute('data-href', 'https://www.facebook.com/GDGCochabamba/');
+        gdgFeed.setAttribute('data-tabs', 'timeline');
+        gdgFeed.setAttribute('data-small-header', 'false');
+        gdgFeed.setAttribute('data-hide-cover', 'false');
+        gdgFeed.setAttribute('data-show-facepile', 'true');
+        gdgFeed.setAttribute('data-width', Math.max(180, Math.min(window.innerWidth, 500)));
+        gdgFeed.setAttribute('data-adapt-container-width', 'true');
+
+        const gdgFeedBlockquote = document.createElement('blockquote');
+        gdgFeedBlockquote.setAttribute('cite', 'https://www.facebook.com/GDGCochabamba/');
+        gdgFeedBlockquote.setAttribute('class', 'fb-xfbml-parse-ignore');
+
+        const gdgFeedA = document.createElement('a');
+        gdgFeedA.setAttribute('href', 'https://www.facebook.com/GDGCochabamba/');
+        gdgFeedA.textContent = 'GDG Cochabamba';
+
+        gdgFeedBlockquote.appendChild(gdgFeedA);
+        gdgFeed.appendChild(gdgFeedBlockquote);
+        gdgFeedContainer.appendChild(gdgFeed);
+        app.appendChild(gdgFeedContainer);
         document.body.appendChild(app);
+
+        window.fbAsyncInit = function () {
+          /* global FB */
+          FB.init({
+            autoLogAppEvents: true,
+            xfbml: true,
+            version: 'v3.2',
+          });
+        };
+
+        (function (d, s, id) {
+          var js;
+          var fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) {return;}
+          js = d.createElement(s); js.id = id;
+          js.src = 'https://connect.facebook.net/en_US/sdk.js';
+          fjs.parentNode.insertBefore(js, fjs);
+        }(document, 'script', 'facebook-jssdk'));
       });
     }
 
@@ -168,6 +214,12 @@
       color: #202020;
       overflow: visible;
     }
+
+    .gdg-feed-container {
+      width: 100%;
+      max-width: 500px;
+    }
+
   </style>
 
 </head>

--- a/src/elements/header-toolbar.html
+++ b/src/elements/header-toolbar.html
@@ -126,7 +126,7 @@
         <paper-icon-button icon="hoverboard:menu" hidden$="[[viewport.isLaptopPlus]]" aria-label="menu" on-tap="openDrawer"></paper-icon-button>
       </div>
       <div layout horizontal center flex>
-        <template is="dom-if" if="{{_shouldRenderLogo(heroSettings)}}">
+        <template is="dom-if" if="{{_shouldRenderLogo(heroSettings, route)}}">
           <a class="toolbar-logo" href="/" hidden$="[[!viewport.isLaptopPlus]]" layout horizontal title="{$ title $}"></a>
         </template>
       </div>
@@ -318,7 +318,10 @@
         });
       }
 
-      _shouldRenderLogo(settings) {
+      _shouldRenderLogo(settings, route) {
+        if (route && route.route !== 'home') {
+          return true;
+        }
         return settings && settings.hideLogo !== undefined;
       }
     }

--- a/src/hoverboard-app.html
+++ b/src/hoverboard-app.html
@@ -212,7 +212,9 @@
             data-route="posts"
             data-path="pages/blog-page.html"
             route="[[subroute]]"
-          ></blog-page>
+          >
+            <slot slot="gdg-cochabamba-feed" name="gdg-cochabamba-feed"></slot>
+          </blog-page>
           <schedule-page
             data-route="schedule"
             data-path="pages/schedule-page.html"

--- a/src/pages/blog-list-page.html
+++ b/src/pages/blog-list-page.html
@@ -85,6 +85,24 @@
         }
       }
 
+      .gdg-cochabamba-feed {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-top: 30px;
+      }
+
+      @media only screen and (min-width: 501px) {
+        .gdg-cochabamba-feed {
+          max-width: 532px;
+          background: var(--diagonal-gradient-reverse-color);
+          padding: 16px 0;
+          margin-left: auto;
+          margin-right: auto;
+          border-radius: var(--border-radius);
+        }
+      }
     </style>
 
     <polymer-helmet
@@ -162,6 +180,9 @@
     <!-- <div class="container-narrow">
       <posts-list posts="[[posts]]"></posts-list>
     </div> -->
+    <div class="gdg-cochabamba-feed">
+      <slot name="gdg-cochabamba-feed"></slot>
+    </div>
 
   </template>
 

--- a/src/pages/blog-page.html
+++ b/src/pages/blog-page.html
@@ -31,7 +31,9 @@
       selected="[[routeData.page]]"
       selected-attribute="active"
     >
-      <blog-list-page data-route="" data-path="./blog-list-page.html"></blog-list-page>
+      <blog-list-page data-route="" data-path="./blog-list-page.html">
+        <slot slot="gdg-cochabamba-feed" name="gdg-cochabamba-feed"></slot>
+      </blog-list-page>
       <post-page data-route="posts" data-path="./post-page.html" route="[[subRoute]]"></post-page>
     </iron-lazy-pages>
     <footer-block></footer-block>


### PR DESCRIPTION
Closes #47. GDG Cochabamba's FB page feed has been added to /posts, it's not completely responsive but it works for the moment, getting all the posts from FB's Graph API and rendering each one of them separately is a lot of work due to the elements being inside Shadow DOM. Also a small issue regarding the display of navbar's DevFest logo on some paths was fixed too.